### PR TITLE
Made dependencies a dict

### DIFF
--- a/src/dependency_manager/manager.py
+++ b/src/dependency_manager/manager.py
@@ -29,7 +29,7 @@ class DependencyManagerAbstract(Singleton, ABC):
                 continue
 
             if dep not in self.dependencies:
-                self.dependencies.append(dep)
+                self.dependencies.update({dep: None})
                 self.dependencies_changed = True
 
     def remove(self, dependencies: list[str]):
@@ -41,7 +41,7 @@ class DependencyManagerAbstract(Singleton, ABC):
                 continue
 
             if dep in self.dependencies:
-                self.dependencies.remove(dep)
+                self.dependencies.pop(dep)
                 self.dependencies_changed = True
 
     def write(self, dry_run=False):
@@ -73,13 +73,13 @@ class DependencyManagerAbstract(Singleton, ABC):
         return None
 
     @cached_property
-    def dependencies(self) -> list[pkg_resources.Requirement]:
+    def dependencies(self) -> dict[pkg_resources.Requirement, None]:
         """
         Extract list of dependencies from requirements.txt file.
         Same order of requirements is maintained, no alphabetical sorting is done.
         """
         if not self.dependency_file:
-            return []
+            return dict()
         with open(self.dependency_file, "r", encoding="utf-8") as f:
             lines = f.readlines()
-        return list(pkg_resources.parse_requirements(lines))
+        return {req: None for req in pkg_resources.parse_requirements(lines)}

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -76,12 +76,12 @@ class TestManager:
 
         DependencyManager().add(["my_pkg==1"])
         assert len(manager.dependencies) == 5
-        my_pkg = manager.dependencies[-1]
+        my_pkg = next(reversed(manager.dependencies))
         assert str(my_pkg) == "my_pkg==1"
 
         DependencyManager().add(["my_pkg_no_ver"])
         assert len(manager.dependencies) == 6
-        my_pkg = manager.dependencies[-1]
+        my_pkg = next(reversed(manager.dependencies))
         assert str(my_pkg) == "my_pkg_no_ver"
 
         # don't add already existing dep
@@ -108,7 +108,7 @@ class TestManager:
         assert manager.dependency_file == path_with_req / "requirements.txt"
         assert len(manager.dependencies) == 4
 
-        first_dep = manager.dependencies[0]
+        first_dep = next(iter(manager.dependencies))
         manager.remove([str(first_dep)])
         assert len(manager.dependencies) == 3
 
@@ -125,7 +125,7 @@ class TestManager:
                 return path_with_req
 
         manager = DependencyManager()
-        first_dep = manager.dependencies[0]
+        first_dep = next(iter(manager.dependencies))
         manager.remove([str(first_dep)])
         manager.write(dry_run=True)
         with open(manager.dependency_file, "r", encoding="utf-8") as dep_file:
@@ -141,7 +141,7 @@ class TestManager:
                 return path_with_req_with_cleanup
 
         manager = DependencyManager()
-        first_dep = manager.dependencies[0]
+        first_dep = next(iter(manager.dependencies))
         manager.remove([str(first_dep)])
         manager.write()
         with open(manager.dependency_file, "r", encoding="utf-8") as dep_file:


### PR DESCRIPTION
## Overview 

Changes dependencies from list to a keys-only dict

## Description

When `DependencyManager` `add()`/`remove()` is called it checks for membership to avoid redundancy. This is expensive (O(n)) in a list.

The reason why a dictionary was chosen is because they preserve insertion order since python 3.7 (any version not only CPython, see https://docs.python.org/3/library/stdtypes.html#dictionary-view-objects), have (amortized) O(1) membership check, and insertion/deletion. A set would be ideal, but it does not preserve order.

The caveat is that the `dependencies` feels awkward to handle if you don't know it is a keys-only dict.